### PR TITLE
基本完成30天可用房源的显示和修改

### DIFF
--- a/models/emptyRoomNumber.js
+++ b/models/emptyRoomNumber.js
@@ -23,12 +23,11 @@ module.exports = {
   getAllEmptyRoomNumber: function getAllEmptyRoomNumber () {
     EmptyRoomNumber.find().then(function(day) {
       if (day.length != 30) {
-        module.exports.update();
+        module.exports.initializeEmptyRoomNumber();
       }
     })
     
     // module.exports.deleteAll();
-    // module.exports.initializeEmptyRoomNumber();
     // module.exports.update();
 
     return EmptyRoomNumber.find().sort({"days":1});
@@ -56,8 +55,8 @@ module.exports = {
       }
       for (var i = 1; i < 30; i++) {
         (function(day) {
-          EmptyRoomNumber.find({ days: day}).then(function(day) {
-            if (day.length!=0) {
+          EmptyRoomNumber.find({ days: day}).then(function(num) {
+            if (num.length!=0) {
                EmptyRoomNumber.updateOne({ days: day}, {$set:{'days':day-1}}).exec()
             } else {
               module.exports.create(day-1);
@@ -73,32 +72,30 @@ module.exports = {
   reduceNumberByDaysAndType: function reduceNumberByTypeAndDays(days,type) {
   	EmptyRoomNumber.findOne({ days: days }).then(function(num) {
       if (type == "大房") {
-        EmptyRoomNumber.updateOne({ 'days': days },{$set:{'bigRoom':num.bigRoom-1}}).exec()
+        EmptyRoomNumber.update({ 'days': days },{$set:{'bigRoom':num.bigRoom-1}}).exec()
       } else if (type == "单人房") {
-        EmptyRoomNumber.updateOne({ 'days': days },{$set:{'singleRoom':num.singleRoom-1}}).exec()
+        EmptyRoomNumber.update({ 'days': days },{$set:{'singleRoom':num.singleRoom-1}}).exec()
       } else if (type == "双人房") {
-        EmptyRoomNumber.updateOne({ 'days': days },{$set:{'doubleRoom':num.bigRdoubleRoomoom-1}}).exec()
+        EmptyRoomNumber.update({ 'days': days },{$set:{'doubleRoom':num.doubleRoom-1}}).exec()
       }
     })
   },
 
   // 增加某天某个房间类型的数量  取消预定时调用/退房时调用（退房时days应传入0）参数days是number,type是string
   addNumberByDaysAndType: function addNumberByDaysAndType(days,type) {
-    EmptyRoomNumber.update({ 'days': 0 },{$set:{'bigRoom':666}})
     EmptyRoomNumber.findOne({ days: days }).then(function(num) {
       if (type == "大房") {
-        EmptyRoomNumber.update({ 'days': days },{$set:{'bigRoom':num.bigRoom+1}})
+        EmptyRoomNumber.update({ 'days': days },{$set:{'bigRoom':num.bigRoom+1}}).exec()
       } else if (type == "单人房") {
-        EmptyRoomNumber.update({ 'days': days },{$set:{'singleRoom':num.singleRoom+1}})
+        EmptyRoomNumber.update({ 'days': days },{$set:{'singleRoom':num.singleRoom+1}}).exec()
       } else if (type == "双人房") {
-        EmptyRoomNumber.update({ 'days': days },{$set:{'doubleRoom':num.bigRdoubleRoomoom+1}})
+        EmptyRoomNumber.update({ 'days': days },{$set:{'doubleRoom':num.doubleRoom+1}}).exec()
       }
     })
   },
 
   // 增加某个房间类型的数量  管理客房中增加客房时调用
   addNumberByType: function addNumberByType(type) {
-    EmptyRoomNumber.update({ 'days': 0 },{$set:{'bigRoom':666}});
     for(var i = 0; i < 30; i++) {
       (function(day) {
         module.exports.addNumberByDaysAndType(day,type);

--- a/models/rooms.js
+++ b/models/rooms.js
@@ -23,8 +23,8 @@ module.exports = {
   },
 
   // 修改房间信息
-  updateRoom: function updateRoom (room) {
-    return Room.updateOne({'number':room.number},{$set:{'type':room.type, value:room.value}}).exec()
+  updateRoomValue: function updateRoomValue (room) {
+    return Room.updateOne({'number':room.number},{$set:{'value':room.value}}).exec()
   },
 
   // 获得单人房房间的总数
@@ -43,13 +43,9 @@ module.exports = {
   },
   
   // 用于登记入住管理：
-
-  // 根据房间类型随机获得一个空房的信息, 类型：{number:xx, type:xx, value:xx, status:0}
+  // 根据房间类型随机获得空房的信息,可能返回有多个 类型：{number:xx, type:xx, value:xx, status:0}
   getRoomIdByType: function getRoomIdByType (type) {
-    Room.find({type:type, status:0}).then(function(rooms) {
-      var randNum = Math.floor(Math.random()*rooms.length)
-      return rooms[randNum];
-    })
+    Room.find({type:type, status:0}).exec()
   },
 
   // 根据房间号码登记入住/退房(退房时customerId传入"0")

--- a/views/manageroom.ejs
+++ b/views/manageroom.ejs
@@ -23,7 +23,7 @@
           <div class="eight wide column">
             <div class="manage_room"><ul>
               <li><a href="/manageroom/addroom"><h2>添加客房</h1></a></li>
-              <li><a href="/manageroom/updateroom"><h2>调整客房</h1></a></li>
+              <li><a href="/manageroom/updateroom"><h2>修改房价</h1></a></li>
               <li><a href="/manageroom/deleteroom"><h2>删除客房</h1></a></li>
             </ul></div>
           </div>

--- a/views/updateroom.ejs
+++ b/views/updateroom.ejs
@@ -20,16 +20,12 @@
       <div class="main">
         <div class="ui grid">
           <div class="four wide column"></div>
-          <div class="caozuo"><h2>修改客房</h2></div>
+          <div class="caozuo"><h2>修改房价</h2></div>
             <div class="content">
               <form class="ui form segment" method="post" id = "myFrm">
               <div class="field required">
                 <label>房间号</label>
                 <input placeholder="房间号" type="text" name="roomnumber">
-              </div>
-              <div class="field required">
-                <label>房间类型</label>
-                <input placeholder="房间类型" type="text" name="roomtype">
               </div>
               <div class="field required">
                 <label>房间价格</label>


### PR DESCRIPTION
解决：
在manageroom页面中增删房间后不能成功更新数据库，所以manage页面中的数量也没有及时更新，现在增删客房可以改变manage首页的可用房量。
遗留问题：
在manage页面中显示剩余房间数量的初始化时，由于数据库初始化比查询返回执行的慢，所以需要多次刷新才能初始化完成，并且有缺失值
manage页面中的日期还是偏移日期，不是实际的月日
盘点结算没实现，并且结算时应该更新可用房源（左移一天）